### PR TITLE
Fix reference to a non-English version of docs

### DIFF
--- a/lib/generators/docs/templates/docs/src/.vuepress/config.js
+++ b/lib/generators/docs/templates/docs/src/.vuepress/config.js
@@ -61,7 +61,7 @@ module.exports = {
   },
 
   /**
-   * Apply plugins，ref：https://v1.vuepress.vuejs.org/zh/plugin/
+   * Apply plugins，ref：https://v1.vuepress.vuejs.org/plugin/
    */
   plugins: [
     '@vuepress/plugin-back-to-top',


### PR DESCRIPTION
All the links to the docs page are linked to the English version, while the plugins section is linked to a non English version.

This PR changes the Link to the English version