### PR TITLE
add yarn-error.log to gitignore file

### DIFF
--- a/lib/generators/blog/templates/_gitignore
+++ b/lib/generators/blog/templates/_gitignore
@@ -2,6 +2,7 @@ pids
 logs
 node_modules
 npm-debug.log
+yarn-error.log
 coverage/
 run
 dist

--- a/lib/generators/docs/templates/docs/.gitignore
+++ b/lib/generators/docs/templates/docs/.gitignore
@@ -2,6 +2,7 @@ pids
 logs
 node_modules
 npm-debug.log
+yarn-error.log
 coverage/
 run
 dist


### PR DESCRIPTION
When I try to use `yarn`, it sometimes throws an error and create a file called `yarn-error.log` at the root directory.

So I add this file to `.gitignore` in order that it would not be included to git.

![image](https://user-images.githubusercontent.com/69113276/106390251-69b3f880-6422-11eb-83fc-61cd7fa85059.png)
