### PR TITLE
Build and run the generator from docker image support added

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,40 @@ In the desired folder, run the following command to start the VuePress site gene
 npx create-vuepress-site
 # yarn create vuepress-site
 ```
+## Using Docker
+
+Download the Dockerfile:
+
+```bash
+mkdir docker
+cd docker
+wget https://github.com/vuepress/create-vuepress-site/raw/master/docker/Dockerfile
+```
+
+Build the Docker images:
+
+```bash
+docker build -t vuepress-site-generator:latest .
+```
+
+Make a folder where you want to generate the Service:
+
+```bash
+mkdir service
+cd service
+```
+
+Run the generator from image to generate service:
+
+```bash
+docker run -it --rm -v $PWD:/home/vuepress/app vuepress-site-generator
+```
+
+Run and attach interactive shell to the generator docker container to work from inside the running container:
+
+```bash
+docker run -it --rm -v $PWD:/home/vuepress/app vuepress-site-generator /bin/bash
+```
 
 This will create a scaffolded documentation site in the `docs` directory that is enclosed from the rest of the folder.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,49 @@
+FROM ubuntu:18.04
+RUN \
+  # configure the "vuepress" user
+  groupadd vuepress && \
+  useradd vuepress -s /bin/bash -m -g vuepress -G sudo && \
+  echo 'vuepress:vuepress' |chpasswd && \
+  mkdir /home/vuepress/app && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
+  apt-get update && \
+  # install utilities
+  apt-get install -y \
+    wget \
+    sudo && \
+  # install node.js
+  wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
+  # upgrade npm
+  npm install -g npm && \
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /home/vuepress/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# install vuepress
+RUN npm install -g create-vuepress-site
+
+RUN \
+  # fix vuepress user permissions
+  chown -R vuepress:vuepress \
+    /home/vuepress \
+    /usr/local/lib/node_modules && \
+  # cleanup
+  rm -rf \
+    /home/vuepress/.cache/ \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
+
+# expose the working directory
+USER vuepress
+ENV PATH $PATH:/usr/bin
+WORKDIR "/home/vuepress/app"
+VOLUME ["/home/vuepress/app"]
+CMD ["npx", "create-vuepress-site"]


### PR DESCRIPTION
Aim and motivation is to provide ready to use docker images for generator.
User can use generator with just docker can use without having to install NodeJS 
and dependencies etc. and without affecting underlying environment.

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>